### PR TITLE
Initial prototype of returning task results.

### DIFF
--- a/R/redis_backend.R
+++ b/R/redis_backend.R
@@ -38,8 +38,14 @@ RedisBackend <- R6::R6Class(
                        traceback=msg$errors,
                        children=NULL)
             } else {
+                # Prepare the result data - add a result property to 
+                # the list if result data is present
+                res_data <- list(progress=msg$progress)
+                if(!is.null(msg$result)) {
+                    res_data$result <- msg$result
+                }
                 msg = list(status=msg$status,
-                       result=list(progress=msg$progress),
+                       result=res_data,
                        task_id=msg$id,
                        traceback=msg$errors,
                        children=NULL)

--- a/R/ter.R
+++ b/R/ter.R
@@ -43,6 +43,7 @@ TER <- R6::R6Class(
         task=NULL,
         status='PENDING',
         progress=NULL,
+        result=NULL,
         warnings=character(0),
         errors=character(0),
         


### PR DESCRIPTION
Provides the ability to return results from a task undertaken by an Rworker back to the Python client initiating the Celery task.

At present this doesn't take account R<->Python type mappings, the intention is that results are returned in some general interchange format, e.g. JSON, but the code doesn't test this or force serialization of the data in any way - its down to the developer to decide how they want to handle this and implement it on the worker and client sides.