### PR TITLE
Added support for redis password and db selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ SystemRequirements:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate:

--- a/R/backends.R
+++ b/R/backends.R
@@ -8,6 +8,7 @@ backend = function(url) {
     params = parse_url(url)
     provider = params$provider
     params$provider = NULL
+    params <- params[!is.na(params)]
     return(
         do.call(BACKENDS[[provider]]$new, params)
     )

--- a/R/queues.R
+++ b/R/queues.R
@@ -9,6 +9,7 @@ queue = function(url, name) {
     provider = params$provider
     params$provider = NULL
     params$name = name
+    params <- params[!is.na(params)]
     return(
         do.call(QUEUES[[provider]]$new, params)
     )

--- a/R/redis_backend.R
+++ b/R/redis_backend.R
@@ -13,6 +13,7 @@ NULL
 #' ```
 #' @param host Character. Message broker instance address.
 #' @param port Numeric. Message broker port.
+#' @param username Ignored (included for consistency with other non-Redis queues)
 #' @param password Character. Redis password.
 #' @param db Numeric. Database.
 #' @name RedisBackend
@@ -24,14 +25,19 @@ RedisBackend <- R6::R6Class(
     public = list(
         host = NULL,
         port = NULL,
+        username = NULL,
         password = NULL,
         db = NULL,
         
-        initialize = function(host='localhost', port=6379, password=NULL, db=0) {
+        initialize = function(host='localhost', port=6379, username=NULL, password=NULL, db=0) {
             self$host = host
             self$port = port
+            self$username = username
             self$password = password
             self$db = db
+            if (is.na(as.numeric(db2))) {
+                stop("db parameter must be numeric")
+            }
             private$redis_client = redux::hiredis(host=host,
                                                   port=port,
                                                   password=password,

--- a/R/redis_backend.R
+++ b/R/redis_backend.R
@@ -35,7 +35,7 @@ RedisBackend <- R6::R6Class(
             self$username = username
             self$password = password
             self$db = db
-            if (is.na(as.numeric(db2))) {
+            if (is.na(as.numeric(db))) {
                 stop("db parameter must be numeric")
             }
             private$redis_client = redux::hiredis(host=host,

--- a/R/redis_backend.R
+++ b/R/redis_backend.R
@@ -8,11 +8,13 @@ NULL
 #'
 #' @section Usage:
 #' ```
-#' backend <- RedisBackend$new(host='localhost', port=6379)
+#' backend <- RedisBackend$new(host='localhost', port=6379, password=NULL, db=0)
 #' backend$store_result(123, TRUE)
 #' ```
 #' @param host Character. Message broker instance address.
 #' @param port Numeric. Message broker port.
+#' @param password Character. Redis password.
+#' @param db Numeric. Database.
 #' @name RedisBackend
 NULL
 
@@ -22,12 +24,18 @@ RedisBackend <- R6::R6Class(
     public = list(
         host = NULL,
         port = NULL,
-
-        initialize = function(host, port) {
+        password = NULL,
+        db = NULL,
+        
+        initialize = function(host='localhost', port=6379, password=NULL, db=0) {
             self$host = host
             self$port = port
+            self$password = password
+            self$db = db
             private$redis_client = redux::hiredis(host=host,
-                                                  port=port)
+                                                  port=port,
+                                                  password=password,
+                                                  db=db)
         },
 
         store_result = function(id, msg) {

--- a/R/redis_queue.R
+++ b/R/redis_queue.R
@@ -9,13 +9,16 @@ NULL
 #' @section Usage:
 #' ```
 #' queue <- RedisQueue$new(host='localhost',
-#'                         port=6379, name='celery')
+#'                         port=6379, name='celery',
+#'                         password=NULL, db=0)
 #' msg <- queue$pull()
 #' queue$push(msg)
 #' ```
 #' @param name The name of the queue.
 #' @param host Message broker instance address.
 #' @param port Message broker port.
+#' @param password Redis password
+#' @param db Database number
 #'
 #' @name RedisQueue
 NULL
@@ -27,10 +30,14 @@ RedisQueue <- R6::R6Class(
         host = NULL,
         port = NULL,
         name = NULL,
+        password = NULL,
+        db = NULL,
 
-        initialize = function(name='celery', host='localhost', port=6379) {
+        initialize = function(name='celery', host='localhost', port=6379, password=NULL, db=0) {
             self$host = host
             self$port = port
+            self$password = password
+            self$db = db
             if(missing(name)) {
                    stop('Must provide Queue name')
             } else {
@@ -49,7 +56,9 @@ RedisQueue <- R6::R6Class(
 
         connect = function() {
             private$channel = redux::hiredis(host=self$host,
-                                             port=self$port)
+                                             port=self$port, 
+                                             password=self$password, 
+                                             db=self$db)
         }
     ),
 

--- a/R/redis_queue.R
+++ b/R/redis_queue.R
@@ -17,6 +17,7 @@ NULL
 #' @param name The name of the queue.
 #' @param host Message broker instance address.
 #' @param port Message broker port.
+#' @param username Ignored (included for consistency with other non-Redis queues)
 #' @param password Redis password
 #' @param db Database number
 #'
@@ -30,14 +31,19 @@ RedisQueue <- R6::R6Class(
         host = NULL,
         port = NULL,
         name = NULL,
+        username = NULL,
         password = NULL,
         db = NULL,
 
-        initialize = function(name='celery', host='localhost', port=6379, password=NULL, db=0) {
+        initialize = function(name='celery', host='localhost', port=6379, username=NULL, password=NULL, db=0) {
             self$host = host
             self$port = port
+            self$username = username
             self$password = password
             self$db = db
+            if (is.na(as.numeric(db2))) {
+                stop("db parameter must be numeric")
+            }
             if(missing(name)) {
                    stop('Must provide Queue name')
             } else {

--- a/R/redis_queue.R
+++ b/R/redis_queue.R
@@ -41,7 +41,7 @@ RedisQueue <- R6::R6Class(
             self$username = username
             self$password = password
             self$db = db
-            if (is.na(as.numeric(db2))) {
+            if (is.na(as.numeric(db))) {
                 stop("db parameter must be numeric")
             }
             if(missing(name)) {

--- a/R/util.R
+++ b/R/util.R
@@ -1,9 +1,10 @@
 #' @importFrom stringr str_match
 #' @keywords internal
 parse_url = function(url) {
-    parsed = as.list(stringr::str_match(url, "(.*)://(.*):(\\d*)"))
-    parsed = parsed[-1]
-    names(parsed) <- c("provider", "host", "port")
+    #parsed = as.list(stringr::str_match(url, "(.*)://(.*):(\\d*)"))
+    parsed = as.list(stringr::str_match(url, "(.*)://(:(.*)@)?([^:/]*)(:(\\d*))?(/(\\d*))?"))
+    parsed = parsed[-c(1,3,6, 8)]
+    names(parsed) <- c("provider", "password", "host", "port", "db")
     return(parsed)
 }
 

--- a/R/util.R
+++ b/R/util.R
@@ -1,10 +1,10 @@
 #' @importFrom stringr str_match
 #' @keywords internal
 parse_url = function(url) {
-    #parsed = as.list(stringr::str_match(url, "(.*)://(.*):(\\d*)"))
-    parsed = as.list(stringr::str_match(url, "(.*)://(:(.*)@)?([^:/]*)(:(\\d*))?(/(\\d*))?"))
-    parsed = parsed[-c(1,3,6, 8)]
-    names(parsed) <- c("provider", "password", "host", "port", "db")
+    parsed = as.list(stringr::str_match(url, 
+                                        "(.*)://((.+)?:(.+)@)?([^:/]*)(:(\\d*))?(/(\\w*))?"))
+    parsed = parsed[-c(1,3,7,9)]
+    names(parsed) <- c("provider", "username", "password", "host", "port", "db")
     return(parsed)
 }
 

--- a/man/RedisBackend.Rd
+++ b/man/RedisBackend.Rd
@@ -8,6 +8,8 @@
 
 \item{port}{Numeric. Message broker port.}
 
+\item{username}{Ignored (included for consistency with other non-Redis queues)}
+
 \item{password}{Character. Redis password.}
 
 \item{db}{Numeric. Database.}

--- a/man/RedisBackend.Rd
+++ b/man/RedisBackend.Rd
@@ -7,12 +7,16 @@
 \item{host}{Character. Message broker instance address.}
 
 \item{port}{Numeric. Message broker port.}
+
+\item{password}{Character. Redis password.}
+
+\item{db}{Numeric. Database.}
 }
 \description{
 This object establishes an interface with Redis as a results backend.
 }
 \section{Usage}{
-\preformatted{backend <- RedisBackend$new(host='localhost', port=6379)
+\preformatted{backend <- RedisBackend$new(host='localhost', port=6379, password=NULL, db=0)
 backend$store_result(123, TRUE)
 }
 }

--- a/man/RedisQueue.Rd
+++ b/man/RedisQueue.Rd
@@ -9,13 +9,18 @@
 \item{host}{Message broker instance address.}
 
 \item{port}{Message broker port.}
+
+\item{password}{Redis password}
+
+\item{db}{Database number}
 }
 \description{
 This object establishes an interface for Redis as a message broker
 }
 \section{Usage}{
 \preformatted{queue <- RedisQueue$new(host='localhost',
-                        port=6379, name='celery')
+                        port=6379, name='celery',
+                        password=NULL, db=0)
 msg <- queue$pull()
 queue$push(msg)
 }

--- a/man/RedisQueue.Rd
+++ b/man/RedisQueue.Rd
@@ -10,6 +10,8 @@
 
 \item{port}{Message broker port.}
 
+\item{username}{Ignored (included for consistency with other non-Redis queues)}
+
 \item{password}{Redis password}
 
 \item{db}{Database number}

--- a/man/Rworker.Rd
+++ b/man/Rworker.Rd
@@ -5,8 +5,12 @@
 \alias{rworker}
 \title{Rworker object}
 \usage{
-rworker(name = "celery", workers = 2, queue = "redis://localhost:6379",
-  backend = "redis://localhost:6379")
+rworker(
+  name = "celery",
+  workers = 2,
+  queue = "redis://localhost:6379",
+  backend = "redis://localhost:6379"
+)
 }
 \arguments{
 \item{name}{The name of the message queue.}
@@ -29,25 +33,25 @@ process pool.
 
 \section{Details}{
 
-\code{$new()} creates new Rworker instance. Process pool is started and Queue
+\verb{$new()} creates new Rworker instance. Process pool is started and Queue
 connection is established during instantiation.
 
-\code{$start_pool()} starts all processes in the background process pool
+\verb{$start_pool()} starts all processes in the background process pool
 
-\code{$kill_pool()} kills all processes in the background process pool
+\verb{$kill_pool()} kills all processes in the background process pool
 
-\code{$pool} processes list
+\verb{$pool} processes list
 
-\code{$task()} registers function as task to be remotelly executed
+\verb{$task()} registers function as task to be remotelly executed
 
-\code{$tasks} list of registered tasks
+\verb{$tasks} list of registered tasks
 
-\code{$consume()} listens for message broker messages and send them to be executed
+\verb{$consume()} listens for message broker messages and send them to be executed
 by the worker process pool
 
-\code{$execute()} method used to send tasks and arguments for background execution
+\verb{$execute()} method used to send tasks and arguments for background execution
 
-\code{$update_state()} method used to gather tasks execution status from worker pool
+\verb{$update_state()} method used to gather tasks execution status from worker pool
 
 \code{register_backend()} registers results backend
 }

--- a/man/Worker.Rd
+++ b/man/Worker.Rd
@@ -19,8 +19,8 @@ to the Rworker instance.
 
 \section{Details}{
 
-\code{$listen()} listens for tasks sent by the Rworker instance
-\code{$report()} returns the task execution state to Rworker instance
+\verb{$listen()} listens for tasks sent by the Rworker instance
+\verb{$report()} returns the task execution state to Rworker instance
 }
 
 \examples{


### PR DESCRIPTION
@lecardozo thanks for a useful library! I added support for a Redis password and db selection. URL syntax is consistent with Redis and the redux R package: redis://:password@host:port/db. Both password and db are optional parameters, db defaults to 0 if not specified.